### PR TITLE
Restructure site IA and mobile nav for author portfolio

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,17 +1,51 @@
 title:
+  en: Michał Foerster
+  pl: Michał Foerster
+brand:
   en: Vedalva
   pl: Vedalva
-email: michalfoerster@gmail.com
+email: ""
 description:
-  en: Legends and stories of Noricia. Based on the chronicles of Lingvar, Varduria and oral tradition.
-  pl: Legendy i opowieści Norycji. Na podstawie kronik Lingvaru, Vardurii oraz przekazów ustnych.
+  en: Author website of Michał Foerster. The literary project Ostatni Potop and a curated archive of source texts from the Noricia.
+  pl: Strona autorska Michała Foerstera. Projekt literacki Ostatni Potop oraz uporządkowane archiwum tekstów źródłowych Norycji.
 author: M. Foerster
+author_name: Michał Foerster
+project_title:
+  en: Ostatni Potop
+  pl: Ostatni Potop
 index:
   en: start.html
   pl:
 feed:
   en: /feed.xml
   pl: /feed.xml
+nav:
+  pl:
+    - label: Strona główna
+      url: /
+      key: home
+    - label: Autor
+      url: /o-autorze/
+      key: author
+    - label: Ostatni potop
+      url: /ostatni-potop/
+      key: project
+    - label: Archiwum
+      url: /archiwum/
+      key: archive
+  en:
+    - label: Home
+      url: /start.html
+      key: home
+    - label: Author
+      url: /about/
+      key: author
+    - label: Ostatni potop
+      url: /last-deluge/
+      key: project
+    - label: Archive
+      url: /archive/
+      key: archive
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 future: true

--- a/_data/world_categories.yml
+++ b/_data/world_categories.yml
@@ -1,0 +1,39 @@
+legends:
+  pl:
+    name: Legendy i baśnie
+    description: Opowieści przekazywane między pokoleniami, tworzące wyobraźnię i pamięć świata.
+  en:
+    name: Legends and fables
+    description: Oral and courtly tales that shape the collective memory of the world.
+
+songs:
+  pl:
+    name: Pieśni
+    description: Utwory śpiewane i recytowane; ślady dawnych obrzędów, pamięci i języka.
+  en:
+    name: Songs
+    description: Sung and recited pieces preserving ritual, memory, and language.
+
+chronicles:
+  pl:
+    name: Kroniki
+    description: Materiały kronikarskie i zapisy dziejów, porządkujące fakty świata przedstawionego.
+  en:
+    name: Chronicles
+    description: Chronicle material and records that structure the history of the setting.
+
+translations:
+  pl:
+    name: Przekłady i opracowania
+    description: Tłumaczenia, warianty językowe i komentarze redakcyjne do tekstów świata.
+  en:
+    name: Translations and studies
+    description: Translations, language variants, and editorial notes attached to world texts.
+
+world-materials:
+  pl:
+    name: Materiały świata przedstawionego
+    description: Notatki, dokumenty i artefakty uzupełniające kontekst świata i projektu książkowego.
+  en:
+    name: Worldbuilding materials
+    description: Notes, documents, and in-world artifacts expanding the context of the book project.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,9 +1,3 @@
-{% assign current_lang = page.lang | default: "en" %}
-{% assign footer_prefix = "Copyright" %}
-{% if current_lang == "pl" %}
-  {% assign footer_prefix = "Prawa autorskie" %}
-{% endif %}
-
 <footer class="site-footer">
-  <p>{{ site.title[current_lang] | default: site.title.en }} {{ 'now' | date: '%Y' }} · {{ footer_prefix }} {{ site.author }}</p>
+  <p>{{ 'now' | date: '%Y' }} Prawa autorskie {{ site.author }}</p>
 </footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,9 +3,17 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {% assign current_lang = page.lang | default: "en" %}
+  {% assign page_title = page.seo_title | default: page.title | default: site.title[current_lang] | default: site.title.en %}
+  {% assign page_description = page.description | default: page.excerpt | default: site.description[current_lang] | default: site.description.en %}
 
-  <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title[current_lang] | default: site.title.en | escape }}{% endif %}</title>
-  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description[current_lang] | default: site.description.en }}{% endif %}">
+  <title>{{ page_title | strip_html | strip_newlines | escape }}</title>
+  <meta name="description" content="{{ page_description | strip_html | strip_newlines | truncate: 165 | escape }}">
+  <meta name="author" content="{{ site.author_name | default: site.author | escape }}">
+  <meta name="robots" content="index,follow">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="{{ page_title | strip_html | strip_newlines | escape }}">
+  <meta property="og:description" content="{{ page_description | strip_html | strip_newlines | truncate: 165 | escape }}">
+  <meta property="og:locale" content="{% if current_lang == 'pl' %}pl_PL{% else %}en_US{% endif %}">
 
   <script>
     (function () {

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,17 +1,44 @@
 {% assign current_lang = page.lang | default: "en" %}
-{% assign home_label = "Home" %}
 {% assign toggle_label = "Switch to dark mode" %}
+{% assign active_key = page.nav_key %}
+{% assign nav_open_label = "Open menu" %}
+{% assign nav_close_label = "Close menu" %}
+{% assign nav_menu_text = "Menu" %}
 {% if current_lang == "pl" %}
-  {% assign home_label = "Strona główna" %}
   {% assign toggle_label = "Przełącz na tryb ciemny" %}
+  {% assign nav_open_label = "Otwórz menu" %}
+  {% assign nav_close_label = "Zamknij menu" %}
+  {% assign nav_menu_text = "Menu" %}
+{% endif %}
+{% if page.layout == "post" and active_key == nil %}
+  {% assign active_key = "archive" %}
 {% endif %}
 
 <header class="site-header">
-  <a class="site-title" href="{{ site.index[current_lang] | default: '' | prepend: '/' | prepend: site.baseurl | prepend: site.url }}">{{ site.title[current_lang] | default: site.title.en }}</a>
+  <a class="site-title" href="{{ site.index[current_lang] | default: '' | prepend: '/' | prepend: site.baseurl | prepend: site.url }}">
+    <span class="site-title-main">{{ site.title[current_lang] | default: site.title.en }}</span>
+    <span class="site-title-sub">{{ site.brand[current_lang] | default: site.brand.en }}</span>
+  </a>
 
   <div class="site-controls">
-    <nav class="site-nav" aria-label="Main">
-      <a class="control-link" href="{{ site.index[current_lang] | default: '' | prepend: '/' | prepend: site.baseurl | prepend: site.url }}">{{ home_label }}</a>
+    <button
+      id="nav-toggle"
+      class="control-link nav-toggle"
+      type="button"
+      aria-expanded="false"
+      aria-controls="site-nav-menu"
+      aria-label="{{ nav_open_label }}"
+      data-open-label="{{ nav_open_label }}"
+      data-close-label="{{ nav_close_label }}"
+    >
+      <span class="nav-toggle-icon" aria-hidden="true">☰</span>
+      <span class="nav-toggle-text">{{ nav_menu_text }}</span>
+    </button>
+
+    <nav id="site-nav-menu" class="site-nav" aria-label="Main">
+      {% for item in site.nav[current_lang] %}
+      <a class="control-link nav-link {% if active_key == item.key %}is-active{% endif %}" href="{{ item.url | prepend: site.baseurl | prepend: site.url }}">{{ item.label }}</a>
+      {% endfor %}
     </nav>
 
     <div class="language-switch" aria-label="Languages">

--- a/_includes/source-archive.html
+++ b/_includes/source-archive.html
@@ -1,0 +1,18 @@
+{% assign current_lang = include.lang | default: page.lang | default: "pl" %}
+{% assign posts_in_lang = site.posts | where: "lang", current_lang %}
+{% assign date_format = "%-d.%-m.%Y" %}
+{% assign fallback_type = "other" %}
+{% if current_lang == "pl" %}
+  {% assign fallback_type = "inny gatunek" %}
+{% endif %}
+
+<ul class="latest-list archive-flat-list">
+  {% for post in posts_in_lang %}
+    {% assign current_type = post.text_type | default: fallback_type %}
+  <li class="latest-list-item archive-flat-item">
+    <time class="latest-date" datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: date_format }}</time>
+    <a class="post-link latest-title-link" href="{{ post.url | prepend: site.baseurl | prepend: site.url }}">{{ post.title }}</a>
+    <span class="latest-type">{{ current_type | capitalize }}</span>
+  </li>
+  {% endfor %}
+</ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,15 +4,65 @@
   {% include head.html %}
 
   <body>
-    <main class="Margins">
+    {% assign current_lang = page.lang | default: "en" %}
+    {% assign skip_label = "Skip to content" %}
+    {% if current_lang == "pl" %}
+      {% assign skip_label = "Przejdź do treści" %}
+    {% endif %}
+    <a class="skip-link" href="#content">{{ skip_label }}</a>
+
+    <div class="Margins">
       {% include header.html %}
 
-      <section class="PaperContent">
+      <main id="content" class="PaperContent">
         {{ content }}
-      </section>
+      </main>
 
       {% include footer.html %}
-    </main>
+    </div>
+
+    <script>
+      (function () {
+        var toggle = document.getElementById("nav-toggle");
+        var nav = document.getElementById("site-nav-menu");
+
+        if (!toggle || !nav) {
+          return;
+        }
+
+        var mq = window.matchMedia("(max-width: 640px)");
+
+        function setOpenState(isOpen) {
+          nav.classList.toggle("is-open", isOpen);
+          toggle.setAttribute("aria-expanded", String(isOpen));
+          var openLabel = toggle.getAttribute("data-open-label") || "Open menu";
+          var closeLabel = toggle.getAttribute("data-close-label") || "Close menu";
+          toggle.setAttribute("aria-label", isOpen ? closeLabel : openLabel);
+        }
+
+        setOpenState(false);
+
+        toggle.addEventListener("click", function () {
+          var currentlyOpen = toggle.getAttribute("aria-expanded") === "true";
+          setOpenState(!currentlyOpen);
+        });
+
+        nav.addEventListener("click", function (event) {
+          if (!mq.matches) {
+            return;
+          }
+          if (event.target && event.target.classList.contains("nav-link")) {
+            setOpenState(false);
+          }
+        });
+
+        window.addEventListener("resize", function () {
+          if (!mq.matches) {
+            setOpenState(false);
+          }
+        });
+      })();
+    </script>
 
     <script>
       (function () {

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -5,6 +5,9 @@ layout: default
   {% if page.title %}
   <h1 class="Section">{{ page.title }}</h1>
   {% endif %}
+  {% if page.lead %}
+  <p class="page-lead">{{ page.lead }}</p>
+  {% endif %}
 
   <div class="DocumentBody">
     {{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,9 +2,24 @@
 layout: default
 ---
 <article class="Document" itemscope itemtype="http://schema.org/BlogPosting">
+  {% assign current_lang = page.lang | default: "en" %}
+  {% assign date_format = "%b %-d, %Y" %}
+  {% assign type_label = "Text type" %}
+  {% if current_lang == "pl" %}
+    {% assign date_format = "%-d.%m.%Y" %}
+    {% assign type_label = "Typ tekstu" %}
+  {% endif %}
+
   <header class="post-header">
     <h1 class="Section" itemprop="name headline">{{ page.title }}</h1>
-    <p class="post-meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time>{% if page.author %} · <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}</p>
+    <p class="post-meta">
+      <time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: date_format }}</time>
+      {% if page.author %} · <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}
+      {% if page.text_type %} · {{ type_label }}: {{ page.text_type }}{% endif %}
+    </p>
+    {% if page.lead %}
+    <p class="post-lead">{{ page.lead }}</p>
+    {% endif %}
   </header>
 
   <div class="DocumentBody" itemprop="articleBody">

--- a/_posts/2024-09-12-algard-and-vaitodre.markdown
+++ b/_posts/2024-09-12-algard-and-vaitodre.markdown
@@ -4,6 +4,10 @@ title:  "The Tale of Älgard and Vaitōdre"
 lang: en
 date:   2025-04-12
 ref: algard-vaitodre
+world_category: legends
+text_type: legend
+lead: "A frontier tale of fear, pride, and the awakening of an old force in the Turola Mountains."
+description: "A legend from Noricia about Älgard, the cave of Rhukastar, and the first signs of disaster."
 ---
 
 ## Chapter One

--- a/_posts/2024-09-12-algard-i-vaitodre.markdown
+++ b/_posts/2024-09-12-algard-i-vaitodre.markdown
@@ -4,6 +4,10 @@ title: "Opowieść o Älgardzie i Vaitōdre"
 date: 2025-04-12
 ref: algard-vaitodre
 lang: pl
+world_category: legends
+text_type: legenda
+lead: "Opowieść z pogranicza Turoli o lęku, pysze i przebudzeniu dawnego zagrożenia."
+description: "Legenda o Älgardzie, jaskini Rhukastar i wydarzeniach, które odmieniły los górskiej osady."
 ---
 
 ## Rozdział pierwszy

--- a/_posts/2025-07-02-kroniki-krolow-lingvaru-1.markdown
+++ b/_posts/2025-07-02-kroniki-krolow-lingvaru-1.markdown
@@ -4,6 +4,10 @@ title: "Kroniki królów Lingvaru - część pierwsza"
 date: 2025-07-02
 ref: kkl-1
 lang: pl
+world_category: chronicles
+text_type: kronika
+lead: "Fragment kronikarski o początkach ludów i najdawniejszych migracjach w świecie Norycji."
+description: "Pierwsza część kroniki Lingvaru: zapis o początkach ludzkości, ucieczkach i formowaniu dawnych państw."
 ---
 
 *Lingvar Thenatis Uvedruns, czyli Kroniki królów Lingvaru*

--- a/_posts/2025-12-04-basn-ostrowiec-i-buraczki.markdown
+++ b/_posts/2025-12-04-basn-ostrowiec-i-buraczki.markdown
@@ -4,9 +4,25 @@ title: "Serce olbrzyma"
 date: 2025-12-04
 ref: fable-hobr
 lang: pl
+world_category: legends
+text_type: baśń
+lead: "Dworska baśń o księciu, który próbuje przechytrzyć olbrzyma i ocalić królestwo."
+description: "Baśń ze Starego Dworu o księciu Ostrowcu, olbrzymie Hobrze i sprycie silniejszym niż miecz."
 ---
 
 *Z legend Starego Dworu. Baśń spisana przez Kersirana*
+
+<p>Posłuchaj nagrania:</p>
+<div class="youtube-embed">
+  <iframe
+    src="https://www.youtube-nocookie.com/embed/SFaKGOopH7w"
+    title="Serce olbrzyma - nagranie"
+    loading="lazy"
+    referrerpolicy="strict-origin-when-cross-origin"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+  ></iframe>
+</div>
 
 Dawno, dawno temu królestwem Andomiru władał stary, mądry król Inzuves. Miał on wielu przyjaciół, którzy wspomagali go w kłopotach, a najsłynniejszym z nich był książę Ostrowiec, o którym będzie ta opowieść.
 

--- a/_posts/2025-12-04-basn-vaitodre.markdown
+++ b/_posts/2025-12-04-basn-vaitodre.markdown
@@ -4,9 +4,25 @@ title: "Baśń o Vaitōdre"
 date: 2025-12-04
 ref: fable-vaitodre
 lang: pl
+world_category: legends
+text_type: baśń
+lead: "Opowieść o Vaitōdre i chwili, gdy przebudzenie smoka wystawia dolinę na próbę."
+description: "Baśń o Vaitōdre, ukrytej dolinie i starciu między światem wiłów a światem ludzi."
 ---
 
 ## Część pierwsza
+
+<p>Posłuchaj nagrania:</p>
+<div class="youtube-embed">
+  <iframe
+    src="https://www.youtube-nocookie.com/embed/HgA154hyUis"
+    title="Baśń o Vaitōdre - nagranie"
+    loading="lazy"
+    referrerpolicy="strict-origin-when-cross-origin"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+  ></iframe>
+</div>
 
 W górach, które nazywamy Turola, wiłowie zaś Velsire, ukryta była dolina Rōdmine. Od niepamiętnych czasów mieszkali tam potomkowie Hilima, wiłowie z plemienia Melarów. 
 

--- a/_posts/2025-12-04-fable-astilar-and-hobr.markdown
+++ b/_posts/2025-12-04-fable-astilar-and-hobr.markdown
@@ -4,6 +4,10 @@ title: "Heart of a Giant"
 date: 2025-12-04
 ref: fable-hobr
 lang: en
+world_category: legends
+text_type: fable
+lead: "A court fable about wit, courage, and the hidden weakness of a giant invader."
+description: "A fable from the Old Court in which Prince Astilar faces the giant Hobr threatening Andomir."
 ---
 
 *From the Legends of the Old Court. A tale written down by Kersiran*

--- a/_posts/2025-12-04-fable-vaitodre.markdown
+++ b/_posts/2025-12-04-fable-vaitodre.markdown
@@ -4,6 +4,10 @@ title: "The Tale of Vaitōdre"
 date: 2025-12-04
 ref: fable-vaitodre
 lang: en
+world_category: legends
+text_type: fable
+lead: "A mountain tale of Vaitōdre and the night when a dragon wakes above the valley."
+description: "A fable about Vaitōdre, hidden valleys, and first contact between the vilas and human settlers."
 ---
 
 ## Part One

--- a/_posts/2026-02-25-ksiezniczka-i-smok-piesn.markdown
+++ b/_posts/2026-02-25-ksiezniczka-i-smok-piesn.markdown
@@ -4,6 +4,10 @@ title: "Księżniczka i smok - pieśń lingvarska"
 lang: pl
 date: 2026-02-25
 ref: princess-dragon-song
+world_category: songs
+text_type: pieśń
+lead: "Krótka pieśń w języku lingvarskim wraz z tłumaczeniem, opisująca ofiarę składaną smokowi."
+description: "Pieśń lingvarska o księżniczce i smoku, z wersją oryginalną i przekładem na język polski."
 ---
 
 Piosenka ligvarska, opisująca ofiary z ludzi.

--- a/_posts/2026-02-25-princess-and-dragon-song.markdown
+++ b/_posts/2026-02-25-princess-and-dragon-song.markdown
@@ -4,6 +4,10 @@ title: "The Princess And The Dragon Song"
 lang: en
 date: 2026-02-25
 ref: princess-dragon-song
+world_category: songs
+text_type: song
+lead: "A short Ligvar song and translation describing ritual sacrifice to the Insatiable."
+description: "The Princess and the Dragon Song in Ligvar and English translation."
 ---
 
 A Ligvar song describing human sacrifices.

--- a/about.md
+++ b/about.md
@@ -1,0 +1,49 @@
+---
+layout: page
+title: Author
+lang: en
+ref: author
+nav_key: author
+permalink: /about/
+seo_title: "Author | Michał Foerster"
+description: "Short biography of Michał Foerster and notes on the Ostatni Potop literary project."
+lead: "I write fantasy set in an original world."
+---
+
+<section class="author-section" aria-labelledby="bio">
+  <h2 id="bio" class="SubSection">Michał Foerster</h2>
+  <div class="intro-row">
+    <img class="site-avatar" src="{{ '/assets/img/avatar.jpg' | prepend: site.baseurl | prepend: site.url }}" alt="Author portrait of Michał Foerster" />
+    <p class="intro-text">Author of the literary project “Ostatni Potop” [The Last Flood] and the world of Noricia. I build a coherent setting where the central novel is expanded through chronicles, songs, and legends.</p>
+  </div>
+</section>
+
+<section class="landing-section" aria-labelledby="practice">
+  <h2 id="practice" class="SubSection">Worldbuilding and narrative</h2>
+  <p>I'm writing a heist fantasy novel, "Ostatni potop." The story takes place in a world explored through published source texts and supplements.</p>
+  <p><a class="text-link" href="{{ '/last-deluge/' | prepend: site.baseurl | prepend: site.url }}">Open the “Ostatni Potop” project page</a></p>
+</section>
+
+<section class="landing-section" aria-labelledby="contact">
+  <h2 id="contact" class="SubSection">Contact</h2>
+  <p>
+    <a id="author-email-link" class="text-link" href="#" rel="nofollow">Show email address</a>
+  </p>
+  <noscript>
+    <p>Please enable JavaScript to reveal the email address.</p>
+  </noscript>
+</section>
+
+<script>
+  (function () {
+    var link = document.getElementById("author-email-link");
+    if (!link) return;
+    var userCodes = [109, 105, 99, 104, 97, 108, 102, 111, 101, 114, 115, 116, 101, 114];
+    var domainCodes = [103, 109, 97, 105, 108, 46, 99, 111, 109];
+    var user = userCodes.map(function (code) { return String.fromCharCode(code); }).join("");
+    var domain = domainCodes.map(function (code) { return String.fromCharCode(code); }).join("");
+    var address = user + "@" + domain;
+    link.setAttribute("href", ["mai", "lto:"].join("") + address);
+    link.textContent = address;
+  })();
+</script>

--- a/archiwum-swiata-redirect.md
+++ b/archiwum-swiata-redirect.md
@@ -1,0 +1,15 @@
+---
+layout: default
+title: Archiwum
+lang: pl
+permalink: /archiwum-swiata/
+nav_key: archive
+seo_title: "Archiwum | Norycja"
+description: "Przekierowanie do aktualnego archiwum."
+---
+
+<script>
+  window.location.replace("{{ '/archiwum/' | prepend: site.baseurl | prepend: site.url }}");
+</script>
+
+<p><a class="text-link" href="{{ '/archiwum/' | prepend: site.baseurl | prepend: site.url }}">Przejdź do Archiwum</a></p>

--- a/archiwum-swiata.md
+++ b/archiwum-swiata.md
@@ -1,0 +1,13 @@
+---
+layout: page
+title: Archiwum
+lang: pl
+ref: archive
+nav_key: archive
+permalink: /archiwum/
+seo_title: "Archiwum | Norycja"
+description: "Archiwum tekstów świata Norycji, uporządkowane chronologicznie."
+lead: "Wszystkie opublikowane teksty źródłowe, ułożone według daty."
+---
+
+{% include source-archive.html lang=page.lang %}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,21 +1,27 @@
 @import url("https://cdn.jsdelivr.net/npm/computer-modern@0.1.3/cmu-serif.css");
 
 :root {
-  --bg: #efece5;
-  --text: #22201c;
-  --muted: #66605a;
-  --line: #d4ccc0;
-  --link: #8f2e15;
-  --link-hover: #b33d20;
+  --bg: #f7f5ef;
+  --surface: #ffffff;
+  --text: #1f1d19;
+  --muted: #625c53;
+  --line: #dbd4c8;
+  --accent: #7b4a2e;
+  --accent-soft: #f0e7dc;
+  --accent-strong: #5f3520;
+  --shadow: 0 12px 30px rgba(25, 23, 19, 0.06);
 }
 
 :root[data-theme="dark"] {
-  --bg: #101217;
-  --text: #ece5d8;
-  --muted: #b2a894;
-  --line: #303743;
-  --link: #efc676;
-  --link-hover: #ffd98f;
+  --bg: #101318;
+  --surface: #161c24;
+  --text: #e8decb;
+  --muted: #b8ab93;
+  --line: #2b3646;
+  --accent: #e7bc77;
+  --accent-soft: #26211a;
+  --accent-strong: #f1cd92;
+  --shadow: none;
 }
 
 html,
@@ -28,40 +34,68 @@ body {
 
 body {
   font-family: "CMU Serif", "Latin Modern Roman", Georgia, "Times New Roman", serif;
-  line-height: 1.6;
+  line-height: 1.72;
+  text-rendering: optimizeLegibility;
+}
+
+.skip-link {
+  position: absolute;
+  left: -1000px;
+  top: 0;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--line);
+  padding: 0.45rem 0.8rem;
+}
+
+.skip-link:focus {
+  left: 0.8rem;
+  top: 0.8rem;
+  z-index: 1000;
 }
 
 .Margins {
-  max-width: 960px;
+  max-width: 1060px;
   margin: 0 auto;
-  padding: 1.25rem 1rem 3rem;
+  padding: 1.4rem 1rem 3.2rem;
 }
 
 .site-header {
-  width: 100%;
-  margin: 0 0 1rem;
   display: flex;
-  justify-content: space-between;
   align-items: flex-start;
+  justify-content: space-between;
   gap: 1rem;
-  padding-bottom: 0.85rem;
   border-bottom: 1px solid var(--line);
+  margin-bottom: 2.1rem;
+  padding-bottom: 1rem;
 }
 
 .site-title {
-  font-family: "CMU Serif", "Latin Modern Roman", Georgia, "Times New Roman", serif;
-  font-weight: 700;
-  font-size: 1.5rem;
   text-decoration: none;
-  color: var(--text);
-  letter-spacing: 0.02em;
+  color: inherit;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.site-title-main {
+  font-size: clamp(1.2rem, 2.3vw, 1.55rem);
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.site-title-sub {
+  font-size: 0.86rem;
+  color: var(--muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .site-controls {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 0.5rem;
+  gap: 0.45rem 0.8rem;
   flex-wrap: wrap;
 }
 
@@ -69,54 +103,323 @@ body {
 .language-switch {
   display: flex;
   align-items: center;
+  gap: 0.15rem;
+  flex-wrap: wrap;
+}
+
+.nav-toggle {
+  display: none;
+  align-items: center;
   gap: 0.35rem;
 }
 
+.nav-toggle-icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.nav-toggle-text {
+  line-height: 1;
+}
+
 .control-link {
-  color: var(--text);
+  color: var(--muted);
   text-decoration: none;
-  padding: 0.16rem 0.32rem;
-  font-size: 0.92rem;
-  cursor: pointer;
+  font-size: 0.9rem;
   line-height: 1.2;
-  font-family: inherit;
+  padding: 0.24rem 0.34rem;
+  border-radius: 6px;
   border: 0;
   background: transparent;
+  font-family: inherit;
+  cursor: pointer;
 }
 
-.control-link:hover {
-  color: var(--link);
-  text-decoration: underline;
+.control-link:hover,
+.control-link:focus-visible {
+  color: var(--accent);
+  text-decoration: none;
+  background: var(--accent-soft);
+  outline: 0;
 }
 
+.nav-link.is-active,
 .language-link.is-active {
-  font-family: "CMU Serif", "Latin Modern Roman", Georgia, "Times New Roman", serif;
-  font-weight: 700;
-  text-decoration: underline;
-  text-underline-offset: 0.16em;
+  color: var(--text);
+  background: var(--accent-soft);
 }
 
 .theme-toggle {
+  color: var(--muted);
+  min-width: 2rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 1rem;
 }
 
 .PaperContent {
   width: 100%;
+}
+
+.hero {
+  padding: clamp(1.1rem, 2vw, 1.8rem);
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--accent);
+  border-radius: 12px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  margin-bottom: 1.7rem;
+}
+
+.hero-kicker {
+  margin: 0 0 0.3rem;
+  color: var(--muted);
+  font-size: 0.92rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.hero-title {
+  margin: 0 0 0.65rem;
+  font-size: clamp(1.95rem, 4.5vw, 3rem);
+  line-height: 1.06;
+}
+
+.hero-lead {
+  margin: 0;
+  max-width: 74ch;
+  font-size: clamp(1.04rem, 1.9vw, 1.2rem);
+}
+
+.hero-actions {
+  margin-top: 1.05rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.52rem;
+}
+
+.button-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  text-decoration: none;
+  font-size: 0.92rem;
+  padding: 0.42rem 0.84rem;
+}
+
+.button-link:hover,
+.button-link:focus-visible {
+  background: var(--accent-strong);
+  border-color: var(--accent-strong);
+  text-decoration: none;
+}
+
+.button-link-secondary {
+  color: var(--text);
+  background: transparent;
+  border-color: var(--line);
+}
+
+.button-link-secondary:hover,
+.button-link-secondary:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.landing-section {
+  margin-bottom: 1.5rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.section-copy {
+  margin-bottom: 0;
+}
+
+.landing-grid {
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  margin-top: 1.1rem;
+}
+
+.info-card,
+.category-card {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface);
+  padding: 0.95rem 1rem;
+}
+
+.category-grid {
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin: 1rem 0 1.3rem;
+}
+
+.category-grid > .SubSection {
+  grid-column: 1 / -1;
+  margin-bottom: 0;
+}
+
+.category-card h3 {
+  margin: 0 0 0.3rem;
+  font-size: 1.15rem;
+}
+
+.category-card p {
+  margin: 0 0 0.45rem;
+}
+
+.category-count {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.Document {
+  width: 100%;
+  max-width: 100%;
+}
+
+.Section {
+  margin: 0 0 0.65rem;
+  font-size: clamp(1.7rem, 3.8vw, 2.4rem);
+  line-height: 1.15;
+}
+
+.SubSection {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.25rem, 2.3vw, 1.48rem);
+  line-height: 1.3;
+}
+
+.page-lead,
+.post-lead {
+  margin: 0 0 1rem;
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.DocumentBody {
+  font-size: 1.08rem;
+}
+
+.DocumentBody p,
+.DocumentBody ul,
+.DocumentBody ol,
+.DocumentBody blockquote {
+  margin: 0 0 0.95rem;
+}
+
+.DocumentBody p {
+  text-align: left;
+}
+
+.DocumentBody h2,
+.DocumentBody h3,
+.DocumentBody h4 {
+  margin: 1.5rem 0 0.7rem;
+  line-height: 1.3;
+}
+
+.DocumentBody ul,
+.DocumentBody ol {
+  padding-left: 1.2rem;
+}
+
+.DocumentBody blockquote {
+  border-left: 3px solid var(--line);
+  padding-left: 0.9rem;
+  color: var(--muted);
+}
+
+.DocumentBody code {
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 0.12rem 0.32rem;
+  font-size: 0.9em;
+}
+
+.youtube-embed {
+  width: min(100%, 356px);
+  aspect-ratio: 16 / 9;
+  margin: 0.6rem 0 1.2rem;
+  border: 1px solid var(--line);
+}
+
+.youtube-embed iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+}
+
+.post-header {
+  margin-bottom: 1.2rem;
+}
+
+.post-meta,
+.post-list-meta,
+.latest-date,
+.latest-type {
+  color: var(--muted);
+  font-size: 0.93rem;
+}
+
+.post-meta {
+  margin: 0.2rem 0 0.55rem;
+}
+
+.latest-list {
   margin: 0;
   padding: 0;
-  background: transparent;
-  border: 0;
-  box-shadow: none;
+  list-style: none;
+  border-top: 1px solid var(--line);
+}
+
+.latest-list-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.65rem;
+  align-items: baseline;
+  padding: 0.62rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.latest-title-link {
+  min-width: 0;
+}
+
+.latest-type {
+  white-space: nowrap;
+}
+
+.post-link,
+.text-link {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.post-link:hover,
+.text-link:hover,
+.post-link:focus-visible,
+.text-link:focus-visible {
+  color: var(--accent-strong);
+  text-decoration: underline;
 }
 
 .intro-row {
   display: flex;
   align-items: flex-start;
   gap: 1rem;
-  margin: 0 0 1.6rem;
 }
 
 .site-avatar {
@@ -125,113 +428,27 @@ body {
   border-radius: 50%;
   object-fit: cover;
   flex-shrink: 0;
-  margin: 0;
+  border: 1px solid var(--line);
 }
 
 .intro-text {
   margin: 0;
-  font-size: 1.12rem;
-  text-align: left;
-  text-indent: 0;
-}
-
-.Section {
-  font-family: "CMU Serif", "Latin Modern Roman", Georgia, "Times New Roman", serif;
-  font-weight: 700;
-  font-size: clamp(1.6rem, 3vw, 2.15rem);
-  margin: 0 0 0.85rem;
-}
-
-.SubSection {
-  font-family: "CMU Serif", "Latin Modern Roman", Georgia, "Times New Roman", serif;
-  font-weight: 700;
-  font-size: 1.4rem;
-  margin: 1.2rem 0 0.6rem;
-}
-
-.post-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.9rem;
-}
-
-.post-list-item {
-  padding: 0;
-  border: 0;
-  background: transparent;
-}
-
-.post-list-meta,
-.post-meta {
-  margin: 0;
-  color: var(--muted);
-  font-size: 0.95rem;
-}
-
-.post-list-title {
-  margin: 0.22rem 0 0;
-  font-family: "CMU Serif", "Latin Modern Roman", Georgia, "Times New Roman", serif;
-  font-weight: 700;
-  font-size: clamp(1.25rem, 2.4vw, 1.5rem);
-}
-
-.post-link {
-  color: var(--link);
-  text-decoration: none;
-}
-
-.post-link:hover {
-  color: var(--link-hover);
-  text-decoration: underline;
-}
-
-.DocumentBody {
-  font-size: 1.16rem;
-}
-
-.DocumentBody p {
-  margin: 0 0 1rem;
-  text-align: justify;
-}
-
-.DocumentBody h2,
-.DocumentBody h3,
-.DocumentBody h4 {
-  font-family: "CMU Serif", "Latin Modern Roman", Georgia, "Times New Roman", serif;
-  font-weight: 700;
-  margin: 1.6rem 0 0.8rem;
-}
-
-.DocumentBody ul,
-.DocumentBody ol {
-  margin: 0 0 1rem 1.1rem;
-}
-
-.DocumentBody blockquote {
-  margin: 1rem 0;
-  padding: 0.2rem 0 0.2rem 0.9rem;
-  border-left: 3px solid var(--line);
-  color: var(--muted);
-}
-
-.DocumentBody code {
-  font-size: 0.9em;
-  border: 1px solid var(--line);
-  border-radius: 5px;
-  padding: 0.15rem 0.32rem;
 }
 
 .site-footer {
-  width: 100%;
-  margin: 1.2rem 0 0;
-  color: var(--muted);
-  text-align: center;
-  font-size: 0.88rem;
+  margin-top: 2.3rem;
   border-top: 1px solid var(--line);
-  padding-top: 0.7rem;
+  padding-top: 0.85rem;
+  color: var(--muted);
+  font-size: 0.88rem;
+  text-align: center;
 }
 
-@media (max-width: 640px) {
+.site-footer p {
+  margin: 0.1rem 0;
+}
+
+@media (max-width: 840px) {
   .site-header {
     flex-direction: column;
     align-items: stretch;
@@ -241,13 +458,75 @@ body {
     justify-content: flex-start;
   }
 
-  .site-avatar {
-    width: 74px;
-    height: 74px;
+}
+
+@media (max-width: 640px) {
+  .Margins {
+    padding: 1rem 0.85rem 2.4rem;
   }
 
-  .intro-text,
+  .hero,
+  .info-card,
+  .category-card {
+    border-radius: 8px;
+    padding: 0.85rem 0.88rem;
+  }
+
+  .latest-list-item {
+    grid-template-columns: 1fr;
+    gap: 0.1rem;
+  }
+
+  .site-controls {
+    width: 100%;
+    align-items: center;
+    gap: 0.45rem;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+  }
+
+  .site-nav {
+    display: none;
+    width: 100%;
+    order: 4;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.2rem;
+    margin-top: 0.25rem;
+    padding-top: 0.55rem;
+    border-top: 1px solid var(--line);
+  }
+
+  .site-nav.is-open {
+    display: flex;
+  }
+
+  .site-nav .control-link {
+    padding: 0.25rem 0;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .button-link {
+    width: 100%;
+  }
+
+  .intro-row {
+    flex-direction: column;
+    gap: 0.7rem;
+  }
+
+  .site-avatar {
+    width: 78px;
+    height: 78px;
+  }
+
   .DocumentBody {
-    font-size: 1.04rem;
+    font-size: 1.02rem;
   }
 }

--- a/contact.md
+++ b/contact.md
@@ -1,0 +1,16 @@
+---
+layout: default
+title: Contact
+lang: en
+ref: contact
+nav_key: author
+permalink: /contact/
+seo_title: "Author | Contact"
+description: "Contact moved to the author page."
+---
+
+<script>
+  window.location.replace("{{ '/about/' | prepend: site.baseurl | prepend: site.url }}");
+</script>
+
+<p><a class="text-link" href="{{ '/about/' | prepend: site.baseurl | prepend: site.url }}">Go to Author page</a></p>

--- a/index.html
+++ b/index.html
@@ -1,26 +1,34 @@
 ---
 layout: default
-ref: index
+ref: home
 lang: pl
+nav_key: home
+seo_title: "Michał Foerster | Ostatni Potop i archiwum świata"
+description: "Strona autorska Michała Foerstera: projekt książkowy Ostatni Potop oraz uporządkowane archiwum tekstów źródłowych świata."
 ---
 
-<div class="intro-row">
-  <img
-    class="site-avatar"
-    src="{{ site.baseurl }}/assets/img/avatar.jpg"
-    alt="Avatar {{ site.author }}"
-  />
-  <p class="intro-text">{{ site.description[page.lang] }}</p>
-</div>
+<section class="hero" aria-labelledby="hero-title">
+  <p class="hero-kicker">Strona autorska</p>
+  <h1 id="hero-title" class="hero-title">{{ site.author_name }}</h1>
+  <p class="hero-lead">Tworzę świat fantasy oraz piszę powieść „Ostatni potop”. Na stronie znajdziesz informacje o moim projekcie, materiały i teksty źródłowe.</p>
+  <div class="hero-actions">
+    <a class="button-link" href="{{ '/ostatni-potop/' | prepend: site.baseurl | prepend: site.url }}">Poznaj projekt „Ostatni Potop”</a>
+    <a class="button-link button-link-secondary" href="{{ '/archiwum/' | prepend: site.baseurl | prepend: site.url }}">Przejdź do archiwum</a>
+  </div>
+</section>
 
-<div class="post-list">
+<section class="landing-section" aria-labelledby="latest-title">
+  <h2 id="latest-title" class="SubSection">Ostatnie teksty</h2>
   {% assign posts = site.posts | where: "lang", page.lang %}
-  {% for post in posts %}
-  <article class="post-list-item">
-    <p class="post-list-meta">{{ post.date | date: "%b %-d, %Y" }}</p>
-    <h2 class="post-list-title">
-      <a class="post-link" href="{{ post.url | prepend: site.baseurl | prepend: site.url }}">{{ post.title }}</a>
-    </h2>
-  </article>
-  {% endfor %}
-</div>
+  <ul class="latest-list">
+    {% for post in posts limit: 3 %}
+      {% assign current_type = post.text_type | default: "inny gatunek" %}
+    <li class="latest-list-item">
+      <time class="latest-date" datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%-d.%-m.%Y" }}</time>
+      <a class="post-link latest-title-link" href="{{ post.url | prepend: site.baseurl | prepend: site.url }}">{{ post.title }}</a>
+      <span class="latest-type">{{ current_type | capitalize }}</span>
+    </li>
+    {% endfor %}
+  </ul>
+  <p><a class="text-link" href="{{ '/archiwum/' | prepend: site.baseurl | prepend: site.url }}">Zobacz całe archiwum</a></p>
+</section>

--- a/kontakt.md
+++ b/kontakt.md
@@ -1,0 +1,16 @@
+---
+layout: default
+title: Kontakt
+lang: pl
+ref: contact
+nav_key: author
+permalink: /kontakt/
+seo_title: "Autor | Kontakt"
+description: "Kontakt na stronie autora."
+---
+
+<script>
+  window.location.replace("{{ '/o-autorze/' | prepend: site.baseurl | prepend: site.url }}");
+</script>
+
+<p><a class="text-link" href="{{ '/o-autorze/' | prepend: site.baseurl | prepend: site.url }}">Przejdź do strony Autor</a></p>

--- a/last-deluge.md
+++ b/last-deluge.md
@@ -1,0 +1,35 @@
+---
+layout: page
+title: Ostatni potop
+lang: en
+ref: project
+nav_key: project
+permalink: /last-deluge/
+seo_title: "Ostatni potop | Literary project"
+description: "Overview of the Ostatni potop book project: concept, world tone, supporting materials, and current status."
+lead: "Heist fantasy novel project."
+---
+
+<section class="landing-section" aria-labelledby="book">
+  <h2 id="book" class="SubSection">About the book</h2>
+  <p>“Ostatni potop” [The Last Flood] is a novel project set in the kingdom of Parvaldenia. The story centers on a group of friends entangled in a conspiracy that threatens to destroy the entire kingdom.</p>
+</section>
+
+<section class="landing-section" aria-labelledby="world">
+  <h2 id="world" class="SubSection">About the world</h2>
+  <p>The world of Noricia is built in layers: through the core narrative, chronicles, legends, and songs. The tone is literary, restrained, and serious, balancing myth with history.</p>
+</section>
+
+<section class="landing-section" aria-labelledby="materials">
+  <h2 id="materials" class="SubSection">Fragments and materials</h2>
+  <p>The website publishes source materials, primarily from ancient times. Whenever possible, I add explanations and contextualize them. Excerpts and additions to the novel project will also be posted. Without revealing any details about the novel, of course.</p>
+  <p><a class="text-link" href="{{ '/archive/' | prepend: site.baseurl | prepend: site.url }}">Go to the archive</a></p>
+</section>
+
+<section class="landing-section" aria-labelledby="status">
+  <h2 id="status" class="SubSection">Project status</h2>
+  <p>The project is actively being developed. The second phase of revisions is currently underway. An epilogue is also planned.</p>
+<p>Statistics:</p>
+<p>- 46 chapters</p>
+<p>- approximately 2,000-3,000 words per chapter</p>
+</section>

--- a/o-autorze.md
+++ b/o-autorze.md
@@ -1,0 +1,49 @@
+---
+layout: page
+title: Autor
+lang: pl
+ref: author
+nav_key: author
+permalink: /o-autorze/
+seo_title: "Autor | Michał Foerster"
+description: "Krótki biogram Michała Foerstera oraz informacje o autorskim świecie i projekcie Ostatni potop."
+lead: "Piszę fantasy osadzone w autorskim świecie."
+---
+
+<section class="author-section" aria-labelledby="bio">
+  <h2 id="bio" class="SubSection">Michał Foerster</h2>
+  <div class="intro-row">
+    <img class="site-avatar" src="{{ '/assets/img/avatar.jpg' | prepend: site.baseurl | prepend: site.url }}" alt="Królewna Sōline" />
+    <p class="intro-text">Autor projektu „Ostatni potop” oraz świata Norycji. Konsekwentnie buduje spójne uniwersum, w którym narracja powieściowa spotyka się z materiałami kronikarskimi, pieśniami i legendami.</p>
+  </div>
+</section>
+
+<section class="landing-section" aria-labelledby="warsztat">
+  <h2 id="warsztat" class="SubSection">Praca nad światem i książką</h2>
+  <p>Tworzę powieść heist fantasy "Ostatni potop". Fabuła rozgrywa się w świecie, z którym można się zapoznać dzięki publikowanym tekstom źródłowym i dodatkom.</p>
+  <p><a class="text-link" href="{{ '/ostatni-potop/' | prepend: site.baseurl | prepend: site.url }}">Zobacz stronę projektu „Ostatni potop”</a></p>
+</section>
+
+<section class="landing-section" aria-labelledby="kontakt">
+  <h2 id="kontakt" class="SubSection">Kontakt</h2>
+  <p>
+    <a id="kontakt-mail-link" class="text-link" href="#" rel="nofollow">Pokaż adres e-mail</a>
+  </p>
+  <noscript>
+    <p>Włącz JavaScript, aby wyświetlić adres e-mail.</p>
+  </noscript>
+</section>
+
+<script>
+  (function () {
+    var link = document.getElementById("kontakt-mail-link");
+    if (!link) return;
+    var userCodes = [109, 105, 99, 104, 97, 108, 102, 111, 101, 114, 115, 116, 101, 114];
+    var domainCodes = [103, 109, 97, 105, 108, 46, 99, 111, 109];
+    var user = userCodes.map(function (code) { return String.fromCharCode(code); }).join("");
+    var domain = domainCodes.map(function (code) { return String.fromCharCode(code); }).join("");
+    var address = user + "@" + domain;
+    link.setAttribute("href", ["mai", "lto:"].join("") + address);
+    link.textContent = address;
+  })();
+</script>

--- a/ostatni-potop.md
+++ b/ostatni-potop.md
@@ -1,0 +1,35 @@
+---
+layout: page
+title: Ostatni potop
+lang: pl
+ref: project
+nav_key: project
+permalink: /ostatni-potop/
+seo_title: "Ostatni potop | Projekt literacki"
+description: "Opis projektu książkowego Ostatni potop: założenia, charakter świata, materiały i aktualny status prac."
+lead: "Projekt powieści heist fantasy."
+---
+
+<section class="landing-section" aria-labelledby="o-ksiazce">
+  <h2 id="o-ksiazce" class="SubSection">O książce</h2>
+  <p>„Ostatni potop” to projekt powieściowy rozgrywający się w królestwie Parvaldenii. Historia koncentruje się na grupie przyjaciół zamieszanych w spisek, którego stawką jest zniszczenie całego królestwa.</p>
+</section>
+
+<section class="landing-section" aria-labelledby="o-swiecie">
+  <h2 id="o-swiecie" class="SubSection">O świecie</h2>
+  <p>Świat Norycji jest budowany warstwowo: przez opowieść główną, materiały kronikarskie, legendy i pieśni. Ton projektu jest poważny, literacki i oszczędny, oparty na napięciu między mitem a historią.</p>
+</section>
+
+<section class="landing-section" aria-labelledby="fragmenty">
+  <h2 id="fragmenty" class="SubSection">Fragmenty i materiały</h2>
+  <p>Na stronie publikowane są materiały źródłowe, głównie z zamierzchłych czasów. W ramach możliwości dodaję objaśnienia i tłumaczę ich kontekst. Zamieszczane będą również fragmenty i dodatki do projektu "Ostatni potop". Oczywiście, bez zdradzania szczegółów powieści.</p>
+  <p><a class="text-link" href="{{ '/archiwum/' | prepend: site.baseurl | prepend: site.url }}">Przejdź do archiwum</a></p>
+</section>
+
+<section class="landing-section" aria-labelledby="status">
+  <h2 id="status" class="SubSection">Status projektu</h2>
+  <p>Projekt jest aktywnie rozwijany. Obecnie trwa druga faza poprawek. W planach jest jeszcze epilog.</p>
+<p>Statystyka:</p>
+<p>- 46 rozdziałów</p>
+<p>- około 2-3 tys. słów na rozdział</p>
+</section>

--- a/start.html
+++ b/start.html
@@ -1,26 +1,34 @@
 ---
 layout: default
-ref: index
+ref: home
 lang: en
+nav_key: home
+seo_title: "Michał Foerster | Ostatni Potop and world archive"
+description: "Author website of Michał Foerster: the Ostatni Potop book project and a curated archive of source texts from the world."
 ---
 
-<div class="intro-row">
-  <img
-    class="site-avatar"
-    src="{{ site.baseurl }}/assets/img/avatar.jpg"
-    alt="Avatar {{ site.author }}"
-  />
-  <p class="intro-text">{{ site.description[page.lang] }}</p>
-</div>
+<section class="hero" aria-labelledby="hero-title">
+  <p class="hero-kicker">Author website</p>
+  <h1 id="hero-title" class="hero-title">{{ site.author_name }}</h1>
+  <p class="hero-lead">I am creating a fantasy world and writing the novel “Ostatni Potop”. On this site you will find project information, materials, and source texts.</p>
+  <div class="hero-actions">
+    <a class="button-link" href="{{ '/last-deluge/' | prepend: site.baseurl | prepend: site.url }}">Explore “Ostatni Potop”</a>
+    <a class="button-link button-link-secondary" href="{{ '/archive/' | prepend: site.baseurl | prepend: site.url }}">Visit the archive</a>
+  </div>
+</section>
 
-<div class="post-list">
+<section class="landing-section" aria-labelledby="latest-title">
+  <h2 id="latest-title" class="SubSection">Latest texts</h2>
   {% assign posts = site.posts | where: "lang", page.lang %}
-  {% for post in posts %}
-  <article class="post-list-item">
-    <p class="post-list-meta">{{ post.date | date: "%b %-d, %Y" }}</p>
-    <h2 class="post-list-title">
-      <a class="post-link" href="{{ post.url | prepend: site.baseurl | prepend: site.url }}">{{ post.title }}</a>
-    </h2>
-  </article>
-  {% endfor %}
-</div>
+  <ul class="latest-list">
+    {% for post in posts limit: 3 %}
+      {% assign current_type = post.text_type | default: "other" %}
+    <li class="latest-list-item">
+      <time class="latest-date" datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%-d.%-m.%Y" }}</time>
+      <a class="post-link latest-title-link" href="{{ post.url | prepend: site.baseurl | prepend: site.url }}">{{ post.title }}</a>
+      <span class="latest-type">{{ current_type | capitalize }}</span>
+    </li>
+    {% endfor %}
+  </ul>
+  <p><a class="text-link" href="{{ '/archive/' | prepend: site.baseurl | prepend: site.url }}">Open full archive</a></p>
+</section>

--- a/world-archive-redirect.md
+++ b/world-archive-redirect.md
@@ -1,0 +1,15 @@
+---
+layout: default
+title: Archive
+lang: en
+permalink: /world-archive/
+nav_key: archive
+seo_title: "Archive | Noricia"
+description: "Redirect to the current archive page."
+---
+
+<script>
+  window.location.replace("{{ '/archive/' | prepend: site.baseurl | prepend: site.url }}");
+</script>
+
+<p><a class="text-link" href="{{ '/archive/' | prepend: site.baseurl | prepend: site.url }}">Go to Archive</a></p>

--- a/world-archive.md
+++ b/world-archive.md
@@ -1,0 +1,13 @@
+---
+layout: page
+title: Archive
+lang: en
+ref: archive
+nav_key: archive
+permalink: /archive/
+seo_title: "Archive | Noricia"
+description: "Chronological archive of source texts from the world of Noricia."
+lead: "All published source texts, sorted by publication date."
+---
+
+{% include source-archive.html lang=page.lang %}


### PR DESCRIPTION
## Summary
This PR reorganizes the site into a clearer author portfolio structure while preserving all source texts.

### Main changes
- Reworked site IA and navigation (PL/EN):
  - Home
  - Autor/Author
  - Ostatni potop
  - Archiwum/Archive
- Rebuilt homepage:
  - short hero
  - latest texts list (3 newest)
- Unified `Archiwum świata` + `Teksty źródłowe` into one Archive section.
- Added redirects from legacy archive/contact/source-texts routes.
- Reworked archive listing:
  - single chronological list
  - format: date + title + text type
- Added/updated post metadata for cleaner listings (`text_type`, `lead`, etc.).
- Moved contact into Author page and obfuscated email in frontend code.
- Updated footer to a single copyright line.
- Added mobile-only burger menu (desktop nav unchanged).
- Added YouTube embeds to:
  - `Serce olbrzyma`
  - `Baśń o Vaitōdre`
  with responsive constrained sizing.

## Validation
- `bundle exec jekyll build` passes.

## Notes
- Existing source texts were preserved (no source text removals).
